### PR TITLE
Ignore undeclared selector warnings.

### DIFF
--- a/GVUserDefaults/GVUserDefaults.m
+++ b/GVUserDefaults/GVUserDefaults.m
@@ -114,6 +114,9 @@ static void objectSetter(GVUserDefaults *self, SEL _cmd, id object) {
     return sharedInstance;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundeclared-selector"
+
 - (id)init {
     self = [super init];
     if (self) {
@@ -140,6 +143,8 @@ static void objectSetter(GVUserDefaults *self, SEL _cmd, id object) {
 
     return key;
 }
+
+#pragma GCC diagnostic pop
 
 - (void)generateAccessorMethods {
     unsigned int count = 0;


### PR DESCRIPTION
Clang can be sensitive to the missing implementations of `setupDefaults` and `transformKey:`. Since these calls are properly guarded with `respondsToSelector:`, it's not unreasonable to mute Clang for a bit.
