### PR TITLE
adding B property type for bool. needed for arm64.

### DIFF
--- a/GVUserDefaults/GVUserDefaults.m
+++ b/GVUserDefaults/GVUserDefaults.m
@@ -17,6 +17,7 @@
 
 enum TypeEncodings {
     Char                = 'c',
+    Bool                = 'B',
     Short               = 's',
     Int                 = 'i',
     Long                = 'l',
@@ -200,6 +201,7 @@ static void objectSetter(GVUserDefaults *self, SEL _cmd, id object) {
                 setterImp = (IMP)longLongSetter;
                 break;
 
+            case Bool:
             case Char:
                 getterImp = (IMP)boolGetter;
                 setterImp = (IMP)boolSetter;


### PR DESCRIPTION
Building and running on arm64, a new property type appeared. 'B' for BOOL. so without this, it throws the unknown type exception.
