### PR TITLE
Eliminate compiler warning by casting NSInteger to int

### DIFF
--- a/GVUserDefaults/GVUserDefaults.m
+++ b/GVUserDefaults/GVUserDefaults.m
@@ -64,7 +64,7 @@ static void boolSetter(GVUserDefaults *self, SEL _cmd, bool value) {
 
 static int integerGetter(GVUserDefaults *self, SEL _cmd) {
     NSString *key = [self defaultsKeyForSelector:_cmd];
-    return [[NSUserDefaults standardUserDefaults] integerForKey:key];
+    return (int)[[NSUserDefaults standardUserDefaults] integerForKey:key];
 }
 
 static void integerSetter(GVUserDefaults *self, SEL _cmd, int value) {


### PR DESCRIPTION
I'm seeing a warning in Xcode that complains about an implicit conversion from `long` to `int`. Would it be possible to accept this pull request to reduce the warning?

![screen shot 2014-01-31 at 5 15 02 pm](https://f.cloud.github.com/assets/442307/2056503/9641df36-8ade-11e3-8ee1-a399083f6c37.png)
