### PR TITLE
found some issues with running test

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		0AD6F35F1680DCD400E13802 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		0AD6F3611680DCD400E13802 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		0AD6F3631680DCD400E13802 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
-		0AD6F37C1680DCD400E13802 /* ExampleTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0AD6F37C1680DCD400E13802 /* ExampleTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ExampleTests.octest; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AD6F3851680DCD400E13802 /* ExampleTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ExampleTests-Info.plist"; sourceTree = "<group>"; };
 		0AD6F3871680DCD400E13802 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0AD6F3891680DCD400E13802 /* ExampleTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExampleTests.h; sourceTree = "<group>"; };
@@ -221,7 +221,6 @@
 				0AD6F3771680DCD400E13802 /* Sources */,
 				0AD6F3781680DCD400E13802 /* Frameworks */,
 				0AD6F3791680DCD400E13802 /* Resources */,
-				0AD6F37A1680DCD400E13802 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -286,22 +285,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		0AD6F37A1680DCD400E13802 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		0AD6F3571680DCD400E13802 /* Sources */ = {

--- a/Example/ExampleTests/NoPrefixTests.m
+++ b/Example/ExampleTests/NoPrefixTests.m
@@ -19,7 +19,7 @@
 @dynamic userId;
 @end
 
-
+#warning Before running this test, you should comment out the "transformKey:" method in GVUserDefaults+Properties.m file
 @implementation NoPrefixTests
 
 - (void)setUp {

--- a/Example/ViewController.m
+++ b/Example/ViewController.m
@@ -17,7 +17,7 @@
 
     [[GVUserDefaults standardUserDefaults] addObserver:self forKeyPath:@"boolValue" options:NSKeyValueObservingOptionNew context:nil];
 
-    NSLog(@"Should be null:");
+    NSLog(@"Should be default:");
     NSLog(@"userName: %@", [[NSUserDefaults standardUserDefaults] objectForKey:@"NSUserDefaultUserName"]);
     NSLog(@"--------------------");
 

--- a/GVUserDefaults/GVUserDefaults.m
+++ b/GVUserDefaults/GVUserDefaults.m
@@ -190,6 +190,10 @@ static void objectSetter(GVUserDefaults *self, SEL _cmd, id object) {
     for (int i = 0; i < count; ++i) {
         objc_property_t property = properties[i];
         const char *name = property_getName(property);
+		// Exclude properties not defined in a user custom category
+		if (strcmp(name, "mapping") == 0 || strcmp(name, "userDefaults") == 0)
+			continue;
+		
         const char *attributes = property_getAttributes(property);
 
         char *getter = strstr(attributes, ",G");


### PR DESCRIPTION
Apart from the problem of generating unnecessary accessor methods in `generateAccessorMethods`, I also ran into some issues when running the unit test:
When running test in Xcode 8, I got an error:
>.../Library/Developer/Xcode/DerivedData/projectName/Build/Intermediates/projectName.build/Debug-iphonesimulator/projectNameTests.build/Script-132429AB15ADBB3800DF823E.sh: line 3: /Applications/Xcode.app/Contents/Developer/Tools/RunUnitTests: No such file or directory 

fixed by removing the call to the script in "build phases"-> "run Script" in `ExampleTests` target.

And when running `NoPrefixTests` test, you can't pass without commenting out the `transformKey:` method in `GVUserDefaults+Properties.m`, so I added a warning as a reminder.
