### PR TITLE
Adds support for ignoring synthesized or specified properties

### DIFF
--- a/GVUserDefaults/GVUserDefaults.h
+++ b/GVUserDefaults/GVUserDefaults.h
@@ -11,5 +11,7 @@
 @interface GVUserDefaults : NSObject
 
 + (instancetype)standardUserDefaults;
++ (BOOL)ignoreSynthesizedProperties;
++ (NSArray<NSString *> *)ignoredKeys;
 
 @end

--- a/GVUserDefaults/GVUserDefaults.m
+++ b/GVUserDefaults/GVUserDefaults.m
@@ -133,6 +133,14 @@ static void objectSetter(GVUserDefaults *self, SEL _cmd, id object) {
     return sharedInstance;
 }
 
++ (BOOL)ignoreSynthesizedProperties {
+    return NO;
+}
+
++ (NSArray<NSString *> *)ignoredKeys {
+    return nil;
+}
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundeclared-selector"
 #pragma GCC diagnostic ignored "-Warc-performSelector-leaks"
@@ -192,6 +200,11 @@ static void objectSetter(GVUserDefaults *self, SEL _cmd, id object) {
         const char *name = property_getName(property);
         const char *attributes = property_getAttributes(property);
 
+        if ((void *)(strstr(attributes, ",D")-attributes) == NULL
+            || ([self.class ignoredKeys] != nil
+                && [[self.class ignoredKeys] containsObject:[[NSString alloc] initWithUTF8String:name]])) {
+            continue;
+        }
         char *getter = strstr(attributes, ",G");
         if (getter) {
             getter = strdup(getter + 2);


### PR DESCRIPTION
* Adds class method that, if overridden to return YES, will cause synthesized properties to be ignored.
* Adds class method that, if implemented to return an array of keys, will cause any property with a matching key to be ignored.